### PR TITLE
fix: nginx: [emerg] could not build map_hash

### DIFF
--- a/reverse_proxy.sh
+++ b/reverse_proxy.sh
@@ -1320,6 +1320,7 @@ EOF
 ###################################
 stream_conf() {
   cat > /etc/nginx/stream-enabled/stream.conf <<EOF
+map_hash_bucket_size 128;
 map \$ssl_preread_server_name \$backend {
   ${DOMAIN}                            web;
   ${SUB_DOMAIN}                        xtls;


### PR DESCRIPTION
С длинными доменами можно словить ошибку
```
nginx -t
nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32
nginx: configuration file /etc/nginx/nginx.conf test failed
```
